### PR TITLE
Update React to recognize Atom's custom elements.

### DIFF
--- a/src/browser/ReactDOM.js
+++ b/src/browser/ReactDOM.js
@@ -73,6 +73,8 @@ var ReactDOM = mapObject({
   area: true,
   article: false,
   aside: false,
+  "atom-panel": false,
+  "atom-text-editor": false,
   audio: false,
   b: false,
   base: true,

--- a/src/browser/ui/dom/HTMLDOMPropertyConfig.js
+++ b/src/browser/ui/dom/HTMLDOMPropertyConfig.js
@@ -112,6 +112,7 @@ var HTMLDOMPropertyConfig = {
     mediaGroup: null,
     method: null,
     min: null,
+    mini: HAS_BOOLEAN_VALUE,
     multiple: MUST_USE_PROPERTY | HAS_BOOLEAN_VALUE,
     muted: MUST_USE_PROPERTY | HAS_BOOLEAN_VALUE,
     name: null,


### PR DESCRIPTION
This adds support for the following elements:

```
atom-panel
atom-text-editor
```

And the following attribute:

```
mini
```

This makes it easier to build the UI showcased in Atom's Styleguide using React.

Tested using the following JSX. Both of the following return a mini editor:

```
<atom-text-editor mini>Something you typed...</atom-text-editor>
<atom-text-editor mini={true}>Something you typed...</atom-text-editor>
```

Whereas this returns a full editor:

```
<atom-text-editor mini={false}>Something you typed...</atom-text-editor>
```
